### PR TITLE
Remove r-terra dependency and bump build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: cb729312508d46583f7a42113c9560a60184278c7779029c9b5ae4520f86bc10
 
 build:
-  number: 0
+  number: 1
   noarch: generic
   rpaths:
     - lib/R/lib/
@@ -29,14 +29,12 @@ requirements:
     - r-dbi
     - r-rsqlite
     - r-gtools
-    - r-terra
     - r-processx
   run:
     - r-base
     - r-dbi
     - r-rsqlite
     - r-gtools
-    - r-terra
     - r-processx
 
 test:


### PR DESCRIPTION
### Description
`r-terra` has been removed as it is listed only under "Suggests" in the package DESCRIPTION (not "Imports"), meaning it is an optional dependency used only by the deprecated datasheetSpatRaster() function. The unnecessary r-terra dependency was causing conda solve failures in downstream environments that combine rsyncrosim with other packages, as r-terra pulls in R-version-specific compiled builds that can conflict with newer            toolchains.
                          
### Checklist       
* [x] Used a personal fork of the feedstock to propose changes
* [x]  Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] Re-rendered with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.